### PR TITLE
Fix date parsing bug

### DIFF
--- a/src/main/java/com/cefalo/newstestproject/module/news/entity/NewsEntityV2.java
+++ b/src/main/java/com/cefalo/newstestproject/module/news/entity/NewsEntityV2.java
@@ -13,7 +13,9 @@ public class NewsEntityV2 extends NewsEntity {
 
 
     @NotNull
-    @DateTimeFormat(pattern = "YYYY-MM-DD")
+    // Use standard year-month-day format for parsing the publish date
+    // "YYYY" parses week based year which is incorrect here
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
     @Temporal(TemporalType.DATE)
     @Column(name = "news_publish_date")
     private Date newsPublishDate;


### PR DESCRIPTION
## Summary
- fix incorrect date format in `NewsEntityV2`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d7c37c1cc8331a714d8db34b7a43a